### PR TITLE
P1B: Refactor (public/src/client/topic.js:157): Complex binary expression #241

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -150,12 +150,14 @@ define('forum/topic', [
 		const bookmark = ajaxify.data.bookmark || storage.getItem('topic:' + tid + ':bookmark');
 		const postIndex = ajaxify.data.postIndex;
 		updateUserBookmark(postIndex);
+
+		const hasBookmark = !!bookmark;
+		const onFirstPageOrNoPagination = !config.usePagination || ajaxify.data.pagination.currentPage === 1;
+		const exceedsBookmarkThreshold = ajaxify.data.postcount > ajaxify.data.bookmarkThreshold;
+
 		if (navigator.shouldScrollToPost(postIndex)) {
 			return navigator.scrollToPostIndex(postIndex - 1, true, 0);
-		} else if (bookmark && (
-			!config.usePagination ||
-			(config.usePagination && ajaxify.data.pagination.currentPage === 1)
-		) && ajaxify.data.postcount > ajaxify.data.bookmarkThreshold) {
+		} else if (hasBookmark && onFirstPageOrNoPagination && exceedsBookmarkThreshold) {
 			alerts.alert({
 				alert_id: 'bookmark',
 				message: '[[topic:bookmark-instructions]]',


### PR DESCRIPTION
Closes https://github.com/CMU-313/NodeBB/issues/236

Summary
Refactors handleBookmark in public/src/client/topic.js to remove the complex binary expression at line 157 by introducing well-named boolean variables:

hasBookmark
onFirstPageOrNoPagination
exceedsBookmarkThreshold
This preserves behavior and improves readability/maintainability.

What this file does
public/src/client/topic.js initializes and handles client-side behavior on topic pages (e.g., scrolling to posts, bookmarks, code block handlers, previews, etc.). handleBookmark decides where to scroll on page load and whether to show bookmark instructions.

Scope of refactor
Only the conditional in handleBookmark governing the bookmark/instructions path (formerly at line 157). No logic changes elsewhere.

Qlty evidence
Before:
public/src/client/topic.js
157 Complex binary expression

After:
public/src/client/topic.js

✅ The “Complex binary expression” at line 157 is no longer reported.

Manual runtime validation (UI)
I temporarily added console.log('P1B — VIVEK HANS — handleBookmark executed') inside the refactored block.
Trigger steps:
Start NodeBB and open any topic on page 1.
In DevTools Console, set a bookmark for this topic:
localStorage.setItem('topic:' + ajaxify.data.tid + ':bookmark', '2');
Reload the page. When hasBookmark && onFirstPageOrNoPagination && exceedsBookmarkThreshold is true, the code path executes and the log appears.
I took a screenshot of the Console showing this log and removed the temporary console.log before committing.
<img width="3152" height="1912" alt="image" src="https://github.com/user-attachments/assets/68c4c23d-e8e5-440d-a980-9fe6099a31d1" />

Lint & Test
npm run lint has no new errors
NODEBB_TEST_OFFLINE=1 DISABLE_PLUGIN_REGISTRY=1 npm run test → passes locally
Why this improves adaptability
The original compound condition obscured intent and made future changes risky. Naming sub-conditions documents the logic, makes diffs smaller, and isolates behavior changes to a single, readable line.

Alternatives considered
I considered extracting a helper shouldShowBookmarkAlert(...), but opted to keep the logic inline with named booleans to minimize surface area and avoid extra indirection in a hot path.

Risk/Impact
Low risk; refactor is a straight readability improvement with identical behavior.

Screenshot showing error on line 157 is gone now
<img width="2144" height="586" alt="image" src="https://github.com/user-attachments/assets/a24a0283-0769-4072-83b8-50dc03de3ffd" />
