### PR TITLE
[WIP] change default of downvote visibility to all users

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -143,7 +143,7 @@
     "maintenanceMode": 0,
     "maintenanceModeStatus": 503,
     "upvoteVisibility": "all",
-    "downvoteVisibility": "privileged",
+    "downvoteVisibility": "all",
     "maximumInvites": 0,
     "username:disableEdit": 0,
     "email:disableEdit": 0,


### PR DESCRIPTION
If merged, closes #24 and #25 

# Enable Downvote Visibility by Default
extra documentation on this task is [here](https://docs.google.com/document/d/1eXWyCmeyTJThf4HwCVt7TPVio-L_IWlmjy0PzJXa-18/edit?tab=t.0)

## Summary
This PR addresses User Story 3: allowing users to see who upvoted/downvoted their posts for transparent community engagement.

**Note**: This task was unsuccessful in terms of effort efficiency - significant time was spent on unnecessary implementation before discovering existing functionality. Investigation should have been done first.

## What Was Done
1. **Research**: Initially attempted to write a plugin, then tried mirroring upvote functionality
2. **Discovery**: Found NodeBB already has complete downvote visibility with `postsAPI.getVoters()`, `votes.tpl` template, and proper database/privilege systems
3. **Root Cause**: Feature was disabled by admin panel setting at `http://localhost:4567/admin/settings/reputation` - default was "Only privileged"
4.  Clean up and remove incorrect custom implementation commits
5. Change default downvote visibility from "Only privileged" to "Logged in Users"

## Status
Functionality works when admin setting is toggled, default configuration and cleanup commits is also done. Next up is to make sure it passes lint and test.