### PR TITLE
Add basic translation metrics tracking (count + latency) to translator metrics

### DIFF
--- a/src/translationMetrics.js
+++ b/src/translationMetrics.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// Simple in-memory metrics tracker
+const metrics = {
+	totalRequests: 0,
+	successfulRequests: 0,
+	failedRequests: 0,
+	avgResponseTimeMs: 0,
+};
+
+function record(success, startTime) {
+	const duration = Date.now() - startTime;
+	metrics.totalRequests += 1;
+	if (success) {
+		metrics.successfulRequests += 1;
+	} else {
+		metrics.failedRequests += 1;
+	}
+	// Rolling average latency
+	const n = metrics.totalRequests;
+	metrics.avgResponseTimeMs =
+		((metrics.avgResponseTimeMs * (n - 1)) + duration) / n;
+}
+
+function getMetrics() {
+	return metrics;
+}
+
+module.exports = { record, getMetrics };

--- a/src/translator.js
+++ b/src/translator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const winston = require('winston');
+const { record, getMetrics } = require('./translationMetrics');
 
 function warn(msg) {
 	if (global.env === 'development') {
@@ -8,7 +9,25 @@ function warn(msg) {
 	}
 }
 
-module.exports = require('../public/src/modules/translator.common')(require('./utils'), (lang, namespace) => {
+const translator = require('../public/src/modules/translator.common')(require('./utils'), (lang, namespace) => {
 	const languages = require('./languages');
 	return languages.get(lang, namespace);
 }, warn);
+
+const originalTranslate = translator.translate;
+
+translator.translate = async function (...args) {
+	const start = Date.now();
+	try {
+		const result = await originalTranslate.apply(this, args);
+		record(true, start);
+		return result;
+	} catch (err) {
+		record(false, start);
+		throw err;
+	}
+};
+
+translator.getMetrics = getMetrics;
+
+module.exports = translator;

--- a/test/translator.js
+++ b/test/translator.js
@@ -73,6 +73,17 @@ describe('Translator shim', () => {
 	});
 });
 
+describe('Translation Metrics', () => {
+	it('should track total and successful requests', async () => {
+		const startTotal = shim.getMetrics().totalRequests;
+		await shim.translate('[[global:home]]');
+		const metrics = shim.getMetrics();
+		assert.ok(metrics.totalRequests > startTotal);
+		assert.ok(metrics.successfulRequests > 0);
+	});
+});
+
+
 describe('new Translator(language)', () => {
 	it('should throw if not passed a language', (done) => {
 		assert.throws(() => {


### PR DESCRIPTION
Description
This PR introduces a minimal in-memory metrics tracking feature for the translation service.
The goal is to monitor translator usage and performance without altering existing functionality or tests.

Key changes:
Added a new module src/translationMetrics.js to record:
Total translation requests
Successful and failed requests
Rolling average response time (ms)
Wrapped translate() in src/translator.js to record metrics on each call.
Exposed getMetrics() for inspection and potential future observability.
Added a lightweight test to validate that metrics update after translation calls.

Impact:
No breaking changes.
Does not modify translation behavior or output.
Provides a foundation for tracking system health and performance over time.

Testing:

Ran lint tests to make sure it doesnt break other parts of nodebb
<img width="1426" height="251" alt="Untitled 11" src="https://github.com/user-attachments/assets/9d3a7443-ddf9-47c4-8233-8f165848d2b9" />

Next steps:
Integrate with existing CI to log metrics output after test runs.